### PR TITLE
Enable keyboard shorcuts in no-code editor 

### DIFF
--- a/public/scripts/contentMain.js
+++ b/public/scripts/contentMain.js
@@ -6,4 +6,37 @@ function createPreviewElements( htmlTemplate ){
     $('div[data-gjs-type="wrapper"]').append(htmlTemplate)
 }
 
+document.addEventListener('keydown', e => {
+    console.log( "keyboard DOWN event detected at contentMain: ", e );
+    if( e.ctrlKey || e.metaKey ){
+      switch( e.key ){
+        case "s":
+          //e.preventDefault();
+          /* savePage(); */
+          break;
+        case "z":
+          e.preventDefault();
+          if( e.shiftKey)
+            document.execCommand("redo");
+          else
+            document.execCommand("undo");
+          break;
+        case "c":
+          e.preventDefault();
+          document.execCommand("copy");
+          break;
+        case "v":
+          e.preventDefault();
+          document.execCommand("paste");
+          break;
+        case "x":
+          e.preventDefault();
+          document.execCommand("cut");
+        case "a":
+          e.preventDefault();
+          document.execCommand("selectAll");
+      }
+    }
+  });
+
 /* window.autorun = false; */

--- a/public/scripts/nocodeEditorMain.js
+++ b/public/scripts/nocodeEditorMain.js
@@ -1,3 +1,35 @@
+document.addEventListener('keydown', e => {
+  console.log( "keyboard DOWN event detected at noCodeEditorMain: ", e );
+  if( e.ctrlKey || e.metaKey ){
+    switch( e.key ){
+      case "s":
+        e.preventDefault();
+        editor.runCommand("save-content");
+        break;
+      case "z":
+        e.preventDefault();
+        if( e.shiftKey)
+          document.execCommand("redo");
+        else
+          document.execCommand("undo");
+        break;
+      case "c":
+        e.preventDefault();
+        document.execCommand("copy");
+        break;
+      case "v":
+        e.preventDefault();
+        document.execCommand("paste");
+        break;
+      case "x":
+        e.preventDefault();
+        document.execCommand("cut");
+      case "a":
+        e.preventDefault();
+        document.execCommand("selectAll");
+    }
+  }
+});
 
 
 


### PR DESCRIPTION
(selectall, cut, copy, paste, undo, redo, save).

After trying several methods (involving postMessage, listeners for cut/copy/paste events, adding "allow" attribute to iframe...) this one finally worked as expected.