### PR TITLE
Added the on:click trait to the Button element (q-btn).

### DIFF
--- a/devtools/blocks/quasar/button.json
+++ b/devtools/blocks/quasar/button.json
@@ -332,6 +332,17 @@
     "enabled": true
   },
   {
+	"label": "v-on:click",
+	"name": "v-on:click",
+	"type": "String",
+	"desc": "When the button is clicked then this code will run",
+	"category": "behavior|state",
+	"examples": [
+		"button = !button"
+	],
+	"enabled": true
+  },
+  {
     "label": "disable",
     "name": ":disable",
     "type": "Boolean",

--- a/public/plugins/quasar/blockDefinitions.js
+++ b/public/plugins/quasar/blockDefinitions.js
@@ -1058,6 +1058,17 @@
         "enabled": true
     },
     {
+        "label": "v-on:click",
+        "name": "v-on:click",
+        "type": "String",
+        "desc": "When the button is clicked then this code will run",
+        "category": "behavior|state",
+		"examples": [
+			"button = !button"
+		],
+        "enabled": true
+    },
+    {
         "label": "disable",
         "name": ":disable",
         "type": "Boolean",


### PR DESCRIPTION
It seems that from the current Genie code examples the on:click trait on the button is quite used but it's currently not available on the Genie Builder. This commit adds it.